### PR TITLE
fix: added container references to webepack node externals allow list

### DIFF
--- a/host/webpack.server.config.js
+++ b/host/webpack.server.config.js
@@ -22,7 +22,9 @@ let config = {
 		filename: 'bundle.js',
 	},
 
-	externals: [webpackNodeExternals()],
+	externals: [webpackNodeExternals({
+    allowlist: [/^webpack\/container\/reference\//]
+  })],
 
 	plugins: [
 		new ModuleFederationPlugin({


### PR DESCRIPTION
The issue was that nodeExternals was telling webpack not to compile the container references and instead try to import an external called "webpack/container/reference/remote" that does not exist.